### PR TITLE
Keep original order of variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Depends:
 Imports:
     cli,
     dplyr (>= 0.7),
+    forcats,
     magrittr,
     pander,
     purrr,

--- a/R/skim_print.R
+++ b/R/skim_print.R
@@ -83,8 +83,10 @@ skim_render <- function(.data, groups, FUN, ...) {
   skim_type <- .data$type[1]
   funs_used <- get_funs(skim_type)
   fun_names <- names(funs_used)
+  .data$variable <- forcats::fct_inorder(.data$variable) # To keep original order of variables
   collapsed <- collapse_levels(.data, groups)
   wide <- tidyr::spread(collapsed, "stat", "formatted")
+  wide$variable <- as.character(wide$variable) # To prevent warnings
   if (options$formats$.align_decimal) {
     wide[fun_names] <- lapply(wide[fun_names], align_decimal)
   }

--- a/tests/testthat/test-skim.R
+++ b/tests/testthat/test-skim.R
@@ -82,7 +82,7 @@ test_that("skim_to_wide works as expected.", {
   expect_equal(nrow(input), 5)
   expect_identical(input$type, c("factor", rep("numeric", each = 4)))
   expect_identical(input$variable,
-    c("Species", "Petal.Length", "Petal.Width", "Sepal.Length", "Sepal.Width"))
+    c("Species", "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"))
   expect_identical(input$n, rep("150", each = 5))
   expect_identical(input$top_counts, c("set: 50, ver: 50, vir: 50, NA: 0",
                                        NA, NA, NA, NA))

--- a/tests/testthat/test-skim_print.R
+++ b/tests/testthat/test-skim_print.R
@@ -106,17 +106,17 @@ test_that("Skimr kable prints as expected, 32-bit windows", {
   
   expect_length(input, 18)
   expect_equal(input[15], 
-"| Petal.Length |    0    |   150    | 150 | 3.76 | 1.77 |  1  | 1.6 | 4.35 | 5.1 | 6.9  | ▇▁▁▂▅▅▃▁ |"
-  )
-  expect_equal(input[16], 
-"| Petal.Width  |    0    |   150    | 150 | 1.2  | 0.76 | 0.1 | 0.3 | 1.3  | 1.8 | 2.5  | ▇▁▁▃▃▃▂▂ |"
-)
-  expect_equal(input[17], 
 "| Sepal.Length |    0    |   150    | 150 | 5.84 | 0.83 | 4.3 | 5.1 | 5.8  | 6.4 | 7.9  | ▂▇▅▇▆▅▂▂ |"
   )
-  expect_equal(input[18], 
+  expect_equal(input[16], 
 "| Sepal.Width  |    0    |   150    | 150 | 3.06 | 0.44 |  2  | 2.8 |  3   | 3.3 | 4.4  | ▁▂▅▇▃▂▁▁ |"
   )
+  expect_equal(input[17], 
+"| Petal.Length |    0    |   150    | 150 | 3.76 | 1.77 |  1  | 1.6 | 4.35 | 5.1 | 6.9  | ▇▁▁▂▅▅▃▁ |"
+  )
+  expect_equal(input[18], 
+"| Petal.Width  |    0    |   150    | 150 | 1.2  | 0.76 | 0.1 | 0.3 | 1.3  | 1.8 | 2.5  | ▇▁▁▃▃▃▂▂ |"
+)
 })
 
 test_that("skimr::pander prints as expected", {

--- a/tests/testthat/test-skim_print.R
+++ b/tests/testthat/test-skim_print.R
@@ -73,18 +73,18 @@ test_that("Skimr kable prints as expected, 64-bit", {
   expect_equal(input[10], "")
   expect_equal(input[11], "Variable type: numeric")
   expect_equal(input[12], "")  
-  expect_equal(input[15], 
-"| Petal.Length |    0    |   150    | 150 | 3.76 | 1.77 |  1  | 1.6 | 4.35 | 5.1 | 6.9  | ▇▁▁▂▅▅▃▁ |"
-  )
-  expect_equal(input[16], 
-"| Petal.Width  |    0    |   150    | 150 | 1.2  | 0.76 | 0.1 | 0.3 | 1.3  | 1.8 | 2.5  | ▇▁▁▅▃▃▂▂ |"
-  )
-  expect_equal(input[17],
+  expect_equal(input[15],
 "| Sepal.Length |    0    |   150    | 150 | 5.84 | 0.83 | 4.3 | 5.1 | 5.8  | 6.4 | 7.9  | ▂▇▅▇▆▅▂▂ |"
    )
-  expect_equal(input[18], 
+  expect_equal(input[16], 
 "| Sepal.Width  |    0    |   150    | 150 | 3.06 | 0.44 |  2  | 2.8 |  3   | 3.3 | 4.4  | ▁▂▅▇▃▂▁▁ |"
    )
+  expect_equal(input[17], 
+"| Petal.Length |    0    |   150    | 150 | 3.76 | 1.77 |  1  | 1.6 | 4.35 | 5.1 | 6.9  | ▇▁▁▂▅▅▃▁ |"
+  )
+  expect_equal(input[18], 
+"| Petal.Width  |    0    |   150    | 150 | 1.2  | 0.76 | 0.1 | 0.3 | 1.3  | 1.8 | 2.5  | ▇▁▁▅▃▃▂▂ |"
+  )
   
   # The headers are different on windows
   # Just ignore them


### PR DESCRIPTION
Order of variables changed from alphabetical order to original order by manually converting to factor with the correct order of levels. Solves #350 

Only Windows-related unit tests were modified.