### PR TITLE
Fix vignette title

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -15,6 +15,7 @@ options(width = 120)
 ```
 
 [![Build Status](https://travis-ci.org/ropensci/skimr.svg?branch=master)](https://travis-ci.org/ropensci/skimr)
+[![Build status](https://ci.appveyor.com/api/projects/status/8p93v3t949ubyl06?svg=true)](https://ci.appveyor.com/project/michaelquinn32/skimr)
 [![codecov](https://codecov.io/gh/ropensci/skimr/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/skimr)
 
 `skimr` provides a frictionless approach to summary statistics which conforms

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,7 +15,7 @@ options(width = 120)
 ```
 
 [![Build Status](https://travis-ci.org/ropensci/skimr.svg?branch=master)](https://travis-ci.org/ropensci/skimr)
-[![Build status](https://ci.appveyor.com/api/projects/status/8p93v3t949ubyl06?svg=true)](https://ci.appveyor.com/project/michaelquinn32/skimr)
+[![Build status](https://ci.appveyor.com/api/projects/status/8p93v3t949ubyl06/branch/master?svg=true)](https://ci.appveyor.com/project/michaelquinn32/skimr/branch/master)
 [![codecov](https://codecov.io/gh/ropensci/skimr/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/skimr)
 
 `skimr` provides a frictionless approach to summary statistics which conforms

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ skimr
 
 [![Build
 Status](https://travis-ci.org/ropensci/skimr.svg?branch=master)](https://travis-ci.org/ropensci/skimr)
+[![Build status](https://ci.appveyor.com/api/projects/status/8p93v3t949ubyl06/branch/master?svg=true)](https://ci.appveyor.com/project/michaelquinn32/skimr/branch/master)
 [![codecov](https://codecov.io/gh/ropensci/skimr/branch/master/graph/badge.svg)](https://codecov.io/gh/ropensci/skimr)
 
 `skimr` provides a frictionless approach to summary statistics which

--- a/vignettes/Skimr_defaults.Rmd
+++ b/vignettes/Skimr_defaults.Rmd
@@ -3,7 +3,7 @@ title: "Skimr defaults"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{Skimr defaults}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
I noticed this on CRAN:

![cran_-_package_skimr](https://user-images.githubusercontent.com/4957401/44207088-e3a87800-a129-11e8-98ae-12397ca8bc2d.png)

And thought I'd just fix it rather than create an issue.