### PR TITLE
Update example for creating an integer skimmer

### DIFF
--- a/R/get_skimmers.R
+++ b/R/get_skimmers.R
@@ -40,10 +40,18 @@ NULL
 #'
 #' # Integer and float columns are both "numeric" and are treated the same
 #' # by default. To switch this behavior in another package, add a method.
-#' get_skimmers.integer <- get_skimmers.numeric
+#' get_skimmers.integer <- function(column){
+#'    sfl(
+#'       .type = "integer",
+#'        p50 = stats::quantile(., probs= .50, na.rm = TRUE, names = FALSE, type = 1)
+#'     )
+#'   }
+#' x <- mtcars[c("gear", "carb")]  
+#' class(x$carb) <- "integer"
+#' skim(x)
 #'
 #' # Or, in a local session, use `skim_with` to create a different `skim`.
-#' new_skim <- skim_with(integer = get_skimmers.numeric())
+#' new_skim <- skim_with(integer = get_skimmers.integer())
 #' @export
 get_skimmers <- function(column) {
   UseMethod("get_skimmers")

--- a/R/get_skimmers.R
+++ b/R/get_skimmers.R
@@ -51,7 +51,9 @@ NULL
 #' skim(x)
 #'
 #' # Or, in a local session, use `skim_with` to create a different `skim`.
-#' new_skim <- skim_with(integer = get_skimmers.integer())
+#' # This reverts to the older behavior of integers and floats being treated
+#' # separately, while skimming with the same functions.
+#' new_skim <- skim_with(integer = get_skimmers.numeric())
 #' @export
 get_skimmers <- function(column) {
   UseMethod("get_skimmers")

--- a/man/get_skimmers.Rd
+++ b/man/get_skimmers.Rd
@@ -54,10 +54,18 @@ get_skimmers.my_class <- function(column) {
 
 # Integer and float columns are both "numeric" and are treated the same
 # by default. To switch this behavior in another package, add a method.
-get_skimmers.integer <- get_skimmers.numeric
+get_skimmers.integer <- function(column){
+   sfl(
+      .type = "integer",
+       p50 = stats::quantile(., probs= .50, na.rm = TRUE, names = FALSE, type = 1)
+    )
+  }
+x <- mtcars[c("gear", "carb")]  
+class(x$carb) <- "integer"
+skim(x)
 
 # Or, in a local session, use `skim_with` to create a different `skim`.
-new_skim <- skim_with(integer = get_skimmers.numeric())
+new_skim <- skim_with(integer = get_skimmers.integer())
 }
 \seealso{
 \code{\link[=sfl]{sfl()}}


### PR DESCRIPTION
This fixes the failing example (and I think it's a more explanatory example anyway).