### PR TITLE
In `knit_print`, enable fallback

### DIFF
--- a/R/skim_print.R
+++ b/R/skim_print.R
@@ -116,24 +116,27 @@ NULL
 #' @param ... Additional arguments passed to method
 #' @export
 knit_print.skim_df <- function(x, options = NULL, ...) {
-  assert_is_skim_df(x)
-  if (options$skimr_include_summary %||% TRUE) {
-    summary_stats <- summary(x)
-    summary_string <- build_summary_string(summary_stats)
-    kabled <- knitr::kable(
-      summary_string,
-      # format = "html",
-      table.attr = "style='width: auto;'
-      class='table table-condensed'",
-      col.names = c(" "),
-      caption = "Data summary"
-    )
+  if (is_skim_df(x)) {
+    if (options$skimr_include_summary %||% TRUE) {
+      summary_stats <- summary(x)
+      summary_string <- build_summary_string(summary_stats)
+      kabled <- knitr::kable(
+        summary_string,
+        # format = "html",
+        table.attr = "style='width: auto;'
+        class='table table-condensed'",
+        col.names = c(" "),
+        caption = "Data summary"
+      )
+    } else {
+      kabled <- c()
+    }
+      
+    by_type <- partition(x)
+    knit_print_by_type(by_type, options, kabled)
   } else {
-    kabled <- c()
+    NextMethod("knit_print")
   }
-  by_type <- partition(x)
-
-  knit_print_by_type(by_type, options, kabled)
 }
 
 knit_print_by_type <- function(x, options, summary) {

--- a/tests/testthat/test-skim_print.R
+++ b/tests/testthat/test-skim_print.R
@@ -34,6 +34,13 @@ test_that("knit_print works with skim summaries", {
   expect_matches_file(input, "print/knit_print-summary.txt")
 })
 
+test_that("knit_print appropriately falls back to tibble printing", {
+  skimmed <- skim(iris)
+  reduced <- dplyr::select(skimmed, skim_variable, mean)
+  input <- knit_print(reduced)
+  expect_is(input, "data.frame")
+})
+
 test_that("Summaries can be suppressed within knitr", {
   skimmed <- skim(iris)
   options <- list(skimr_include_summary = FALSE)


### PR DESCRIPTION
Use tibble print instead of erroring if the data type is inappropriate.