### PR TITLE
Check for spaces when removing metadata

### DIFF
--- a/R/skim_print.R
+++ b/R/skim_print.R
@@ -47,9 +47,9 @@ print.one_skim_df <- function(x, n = Inf, width = Inf, n_extra = NULL, ...) {
 
 grab_tibble_metadata <- function(x) {
   if (crayon::has_color()) {
-    grep("^\\\033\\[38;5;\\d{3}m[#\\*]", x)
+    grep("^\\s*\\\033\\[38;5;\\d{3}m[#\\*]", x)
   } else {
-    grep("^[#\\*]", x)
+    grep("^\\s*[#\\*]", x)
   }
 }
 

--- a/tests/testthat/print/groups.txt
+++ b/tests/testthat/print/groups.txt
@@ -11,7 +11,6 @@ Group variables                              Species
 
 ── Variable type: numeric ──────────────────────────────────────────────────────────────────────────
    skim_variable Species    n_missing complete_rate  mean    sd    p0   p25   p50   p75  p100 hist 
- * <chr>         <fct>          <int>         <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <chr>
  1 Sepal.Length  setosa             0             1 5.01  0.352   4.3  4.8   5     5.2    5.8 ▃▃▇▅▁
  2 Sepal.Length  versicolor         0             1 5.94  0.516   4.9  5.6   5.9   6.3    7   ▂▇▆▃▃
  3 Sepal.Length  virginica          0             1 6.59  0.636   4.9  6.22  6.5   6.9    7.9 ▁▃▇▃▂


### PR DESCRIPTION
This handles bugs where certain kinds of metadata were appearing.

Closes #464 