### PR TITLE
Switch match expectation to update = FALSE

### DIFF
--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -25,19 +25,21 @@ expect_NA <- function(object) {
   invisible(act$val)
 }
 
-expect_print_matches_file <- function(object, filename, skip_on_windows = TRUE) {
+expect_print_matches_file <- function(object,
+                                      filename,
+                                      skip_on_windows = TRUE) {
   if (skip_on_windows) testthat::skip_on_os("windows")
   withr::with_options(list(crayon.enabled = FALSE), {
     testthat::expect_known_output(
       print(object),
       filename,
-      update = TRUE,
+      update = FALSE,
       width = 100
     )
   })
 }
 
-expect_matches_file <- function(object, file, update = TRUE,
+expect_matches_file <- function(object, file, update = FALSE,
                                 skip_on_windows = TRUE, ...) {
   if (skip_on_windows) testthat::skip_on_os("windows")
   act <- testthat::quasi_label(rlang::enquo(object), NULL)


### PR DESCRIPTION
Now the reference files won't change when calling the test multiple times.