### PR TITLE
Add option for stripping tibble metadata.

### DIFF
--- a/R/skim_print.R
+++ b/R/skim_print.R
@@ -53,7 +53,7 @@ print.one_skim_df <- function(x,
                               ...) {
   variable_type <- paste("Variable type:", attr(x, "skim_type"))
   top_line <- cli::rule(line = 1, left = variable_type)
-  out <- format(x, ..., n = n, width = width, n_extra = n_extra, dots)
+  out <- format(x, ..., n = n, width = width, n_extra = n_extra)
   if (strip_metadata) {
     metadata <- -1 * grab_tibble_metadata(out)
   } else {

--- a/man/print.Rd
+++ b/man/print.Rd
@@ -38,7 +38,7 @@ default and always print all columns.}
 if the width is too small for the entire tibble. If \code{NULL}, the default,
 will print information about at most \code{tibble.max_extra_cols} extra columns.}
 
-\item{strip_metadata}{Whether tbl metadata should be removed.}
+\item{strip_metadata}{Whether tibble metadata should be removed.}
 
 \item{...}{Other arguments passed on to individual methods.}
 }

--- a/man/print.Rd
+++ b/man/print.Rd
@@ -9,10 +9,10 @@
 \title{Print \code{skim} objects}
 \usage{
 \method{print}{skim_df}(x, include_summary = TRUE, n = Inf,
-  width = Inf, n_extra = NULL, ...)
+  width = Inf, n_extra = NULL, strip_metadata = TRUE, ...)
 
 \method{print}{one_skim_df}(x, n = Inf, width = Inf, n_extra = NULL,
-  ...)
+  strip_metadata = TRUE, ...)
 
 \method{print}{skim_list}(x, n = Inf, width = Inf, n_extra = NULL,
   ...)
@@ -37,6 +37,8 @@ default and always print all columns.}
 \item{n_extra}{Number of extra columns to print abbreviated information for,
 if the width is too small for the entire tibble. If \code{NULL}, the default,
 will print information about at most \code{tibble.max_extra_cols} extra columns.}
+
+\item{strip_metadata}{Whether tbl metadata should be removed.}
 
 \item{...}{Other arguments passed on to individual methods.}
 }


### PR DESCRIPTION
It on by default. But this might be the root cause of some environments not printing.