### PR TITLE
Use crayon::has_color() for metadata strips

### DIFF
--- a/R/skimr-package.R
+++ b/R/skimr-package.R
@@ -17,7 +17,7 @@
 NULL
 
 .onLoad <- function(libname, pkgname) {
-  options(skimr_strip_metadata = .Platform$OS.type != "windows")
+  options(skimr_strip_metadata = crayon::has_color())
 }
 
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -403,7 +403,7 @@
   ],
   "releaseNotes": "https://github.com/ropensci/skimr/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/skimr/blob/master/README.md",
-  "fileSize": "1083.053KB",
+  "fileSize": "1027.472KB",
   "contIntegration": [
     "https://travis-ci.org/ropenscilabs/skimr",
     "https://codecov.io/gh/ropenscilabs/skimr"

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,5 @@
 library(testthat)
 library(skimr)
 
+options(skimr_strip_metadata = TRUE) # Forcing this for the check
 test_check("skimr")


### PR DESCRIPTION
This is a less invasive version of crayon disables.

Closes #569
