### PR TITLE
Update "Supporting Additional Objects" vignette

### DIFF
--- a/vignettes/Supporting_additional_objects.Rmd
+++ b/vignettes/Supporting_additional_objects.Rmd
@@ -39,6 +39,8 @@ nc <- st_read(system.file("shape/nc.shp", package = "sf"))
 
 ```{r}
 class(nc)
+
+class(nc$geometry)
 ```
 
 Unlike the example of having a new type of data in a column of a simple data 
@@ -46,10 +48,11 @@ frame in the "Using skimr" vignette, this is a different type of object
 with special attributes.
 
 In this object there is also a column of a class that does not have default
-skimmers. By default, skimr falls back to use the sfl for character variables.
+skimmers. By default, skimr falls back to use the sfl for character variables. 
 
 ```{r}
 skim(nc$geometry)
+
 ```
 
 
@@ -65,11 +68,13 @@ back to treating the type as a character, which isn't necessarily helpful. In
 this case, you're best off adding your data type with `skim_with()`.
 
 Before we begin, we'll be using the following custom summary statistic
-throughout. It's a naive example, but covers the requirements of what we need.
+throughout. The function gets the geometry's crs and combines it into a string.
 
 ```{r}
-funny_sf <- function(x) {
-  length(x) + 1
+get_crs <- function(column){
+  crs <- sf::st_crs(column)
+  
+  paste0("epsg: ", crs[["epsg"]], " proj4string: '", crs[["proj4string"]], "'")
 }
 ```
 
@@ -92,67 +97,52 @@ default `skimr` percentiles are returned by using `quantile()` five
 times.
 
 Next, we create a custom skimming function. To do this, we need to think about
-the many specific classes of data in the `sf` package.  The following example
-will build  support for `sfc_MULTIPOLYGON`, but note that we'll have to
-eventually think about `sfc_LINESTRING`, `sfc_POLYGON`, `sfc_MULTIPOINT` and
-others if we want to fully support `sf`.
+the many specific classes of data in the `sf` package.  From above, you can see 
+the geometry column has two classes: 1st the specific geometry type (e.g. 
+`sfc_MULTIPOLYGON` `sfc_LINESTRING`, `sfc_POLYGON`, `sfc_MULTIPOINT`) and 2nd the 
+general sfc class. Skimr will try to find a sfl() helper function for the classes 
+in the order they appear in class(.) (see S3 classes for more detail 
+[*Advanced R*](https://adv-r.hadley.nz/s3.html)). The following example will build  
+support for `sfc`, which encompasses all `sf` objects: `sfc_MULTIPOLYGON` 
+`sfc_LINESTRING`, `sfc_POLYGON`, `sfc_MULTIPOINT`. If we want custom skim_with 
+functions we can write sfl() helper functions for the geometry type. 
+
 
 ```{r}
 skim_sf <- skim_with(
-  sfc_MULTIPOLYGON = sfl(
+  sfc = sfl(
     n_unique = n_unique,
     valid = ~ sum(sf::st_is_valid(.)),
-    funny = funny_sf
+    crs= get_crs
   )
 )
 ```
 
 The example above creates a new *function*, and you can call that function on
-a specific column with `sfc_MULTIPOLYGON` data to get the appropriate summary 
-statistics.
-
-```{r}
-skim_sf(nc$geometry)
-```
-
-Creating a function that is a method of the skim_by_type generic
-for the data type allows skimming of an entire data frame that contains some 
-columns of that type.
-
-```{r}
-skim_by_type.sfc_MULTIPOLYGON <- function(mangled, columns, data) {
-  skimmed <- dplyr::summarize_at(data, columns, mangled$funs)
-  build_results(skimmed, columns, NULL)
-}
-```
+a specific column with `sfc` data to get the appropriate summary 
+statistics. The `skim_with` factory also uses the default skimrs for things 
+like factors, characters, numerics, etc. Therefore our `skim_sf` is like the regular
+`skim` function with the added ability to summarize `sfc` columns.
 
 ```{r}
 skim_sf(nc)
 ```
 
-
 Sharing these functions within a separate package requires an export. 
 The simplest way to do this is with Roxygen.
 
 ```{r}
-#' Skimming functions for `sfc_MULTIPOLYGON` objects.
+#' Skimming functions for `sfc` objects.
 #' @export
 skim_sf <- skim_with(
-  sfc_MULTIPOLYGON = sfl(
+  sfc = sfl(
     missing = n_missing,
     n = length,
     n_unique = n_unique,
     valid = ~ sum(sf::st_is_valid(.)),
-    funny = funny_sf
+    crs = get_crs
   )
 )
-
-#' A skim_by_type function for `sfc_MULTIPOLYGON` objects.
-#' @export
-skim_by_type.sfc_MULTIPOLYGON <- function(mangled, columns, data) {
-  skimmed <- dplyr::summarize_at(data, columns, mangled$funs)
-  skimr::build_results(skimmed, columns, NULL)
-}
 ```
 
 While this works within any package, there is an even better approach in this
@@ -174,12 +164,12 @@ a generic we also want to identify the `skim_type` in the `sfl`.
 ```{r}
 #' @importFrom skimr get_skimmers
 #' @export
-get_skimmers.sfc_MULTIPOLYGON <- function(column) {
+get_skimmers.sfc<- function(column) {
   sfl(
-    skim_type = "sfc_MULTIPOLYGON",
+    skim_type = "sfc",
     n_unique = n_unique,
     valid = ~ sum(sf::st_is_valid(.)),
-    funny = funny_sf
+    crs = get_crs
   )
 }
 ```
@@ -209,8 +199,6 @@ data types as well!
 get_default_skimmer_names()
 ```
 
-```
-
 ## Conclusion
 
 This is a very simple example. For a package such as sf the custom statistics
@@ -218,4 +206,4 @@ will likely  be much more complex. The flexibility of `skimr` allows you to
 manage that.
 
 Thanks to Jakub Nowosad, Tiernan Martin, Edzer Pebesma and Michael Sumner for
-inspiring and  helping with the development of this code.
+inspiring and helping with the development of this code.

--- a/vignettes/Supporting_additional_objects.Rmd
+++ b/vignettes/Supporting_additional_objects.Rmd
@@ -52,7 +52,6 @@ skimmers. By default, skimr falls back to use the sfl for character variables.
 
 ```{r}
 skim(nc$geometry)
-
 ```
 
 
@@ -71,9 +70,9 @@ Before we begin, we'll be using the following custom summary statistic
 throughout. The function gets the geometry's crs and combines it into a string.
 
 ```{r}
-get_crs <- function(column){
+get_crs <- function(column) {
   crs <- sf::st_crs(column)
-  
+
   paste0("epsg: ", crs[["epsg"]], " proj4string: '", crs[["proj4string"]], "'")
 }
 ```
@@ -101,7 +100,7 @@ the many specific classes of data in the `sf` package.  From above, you can see
 the geometry column has two classes: 1st the specific geometry type (e.g. 
 `sfc_MULTIPOLYGON` `sfc_LINESTRING`, `sfc_POLYGON`, `sfc_MULTIPOINT`) and 2nd the 
 general sfc class. Skimr will try to find a sfl() helper function for the classes 
-in the order they appear in class(.) (see S3 classes for more detail 
+in the order they appear in `class(.)` (see S3 classes for more detail 
 [*Advanced R*](https://adv-r.hadley.nz/s3.html)). The following example will build  
 support for `sfc`, which encompasses all `sf` objects: `sfc_MULTIPOLYGON` 
 `sfc_LINESTRING`, `sfc_POLYGON`, `sfc_MULTIPOINT`. If we want custom skim_with 
@@ -113,7 +112,7 @@ skim_sf <- skim_with(
   sfc = sfl(
     n_unique = n_unique,
     valid = ~ sum(sf::st_is_valid(.)),
-    crs= get_crs
+    crs = get_crs
   )
 )
 ```
@@ -127,6 +126,24 @@ like factors, characters, numerics, etc. Therefore our `skim_sf` is like the reg
 ```{r}
 skim_sf(nc)
 ```
+
+** This seems unnecessary, but maybe I'm misunderstanding something. I think the skim_with function already creates 
+
+Creating a function that is a method of the skim_by_type generic
+for the data type allows skimming of an entire data frame that contains some 
+columns of that type.
+
+```{r}
+skim_by_type.sfc <- function(mangled, columns, data) {
+  skimmed <- dplyr::summarize_at(data, columns, mangled$funs)
+  build_results(skimmed, columns, NULL)
+}
+```
+
+```{r}
+skim_sf(nc)
+```
+
 
 Sharing these functions within a separate package requires an export. 
 The simplest way to do this is with Roxygen.
@@ -143,6 +160,15 @@ skim_sf <- skim_with(
     crs = get_crs
   )
 )
+
+### This also seems unnecessary
+
+#' A skim_by_type function for `sfc_MULTIPOLYGON` objects.
+#' @export
+skim_by_type.sfc <- function(mangled, columns, data) {
+  skimmed <- dplyr::summarize_at(data, columns, mangled$funs)
+  skimr::build_results(skimmed, columns, NULL)
+}
 ```
 
 While this works within any package, there is an even better approach in this
@@ -164,7 +190,7 @@ a generic we also want to identify the `skim_type` in the `sfl`.
 ```{r}
 #' @importFrom skimr get_skimmers
 #' @export
-get_skimmers.sfc<- function(column) {
+get_skimmers.sfc <- function(column) {
   sfl(
     skim_type = "sfc",
     n_unique = n_unique,

--- a/vignettes/Supporting_additional_objects.Rmd
+++ b/vignettes/Supporting_additional_objects.Rmd
@@ -231,5 +231,5 @@ This is a very simple example. For a package such as sf the custom statistics
 will likely  be much more complex. The flexibility of `skimr` allows you to
 manage that.
 
-Thanks to Jakub Nowosad, Tiernan Martin, Edzer Pebesma and Michael Sumner for
+Thanks to Jakub Nowosad, Tiernan Martin, Edzer Pebesma, Michael Sumner, and Kyle Butts for
 inspiring and helping with the development of this code.


### PR DESCRIPTION
Few changes:
1. Since sf objects have class = "sfc_GEOMETRYTYPE" "sfc", we can define sfl for "sfc" that will be called if there does not exist and sfl for "sfc_GEOMETRYTYPE".

2. I made the example a bit more relevant for sf objects, namely summarizing the CRS (projection) being used. I do think that sf objects should be used as an included sfl, but that could be because I spend a lot of time working with spatial objects ;). 

3. There is mention of skim_by_type.sfc_MULTIPOLYGON, which I don't think needs to be in here unless I misunderstand skimr's code. The "skim_with" factory should already use the base sfl's for numeric, factors, characters, etc. and as you can see the skim_sf() works automatically without the skim_by_type function.