### PR TITLE
Use inherits() instead of is.data.frame()

### DIFF
--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -78,10 +78,10 @@ skim_with <- function(...,
 
   function(data, ...) {
     data_name <- rlang::expr_label(substitute(data))
-    if (!is.data.frame(data)) {
+    if (!inherits(data, "data.frame")) {
       data <- as.data.frame(data)
     }
-    stopifnot(is.data.frame(data))
+    stopifnot(inherits(data, "data.frame"))
 
     .vars <- rlang::quos(...)
     cols <- names(data)


### PR DESCRIPTION
On lazy-loaded, is.data.frame is slower and more expensive, often causing big copies. As it turns out, all is.data.frame does is call inherits(x, "data.frame").  inherits is a internal function, making it much more efficient (and less likely to create unnecessary copies).