### PR TITLE
Since knitr v1.29, knitr::kable() will add the table caption if provided

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -126,6 +126,7 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.0.2
+Remotes: yihui/knitr
 Collate:
     'deprecated.R'
     'dplyr.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -102,7 +102,7 @@ Imports:
     cli,
     crayon,
     dplyr (>= 0.8.0),
-    knitr (>= 1.2),
+    knitr (>= 1.29),
     magrittr (>= 1.5),
     purrr,
     repr,
@@ -126,7 +126,6 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.0.2
-Remotes: yihui/knitr
 Collate:
     'deprecated.R'
     'dplyr.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: skimr
 Title: Compact and Flexible Summaries of Data
-Version: 2.1.1
+Version: 2.1.2
 Authors@R: 
     c(person(given = "Elin",
              family = "Waring",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,10 @@ install:
 # Adapt as necessary starting from here
 
 build_script:
+  - Rscript -e 'install.packages("xfun", repos = "https://cloud.r-project.org")'
   - travis-tool.sh install_github r-lib/devtools
   - travis-tool.sh install_deps
   - travis-tool.sh install_github tidyverse/dplyr
-  - Rscript -e 'update.packages(ask = FALSE, checkBuilt = TRUE)'
   
 environment:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
 # Adapt as necessary starting from here
 
 build_script:
-  - Rscript -e 'install.packages("xfun", repos = "https://cloud.r-project.org")'
+  - Rscript -e "install.packages('xfun', repos = 'https://cloud.r-project.org')"
   - travis-tool.sh install_github r-lib/devtools
   - travis-tool.sh install_deps
   - travis-tool.sh install_github tidyverse/dplyr

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ build_script:
   - travis-tool.sh install_github r-lib/devtools
   - travis-tool.sh install_deps
   - travis-tool.sh install_github tidyverse/dplyr
+  - Rscript -e 'update.packages(ask = FALSE, checkBuilt = TRUE)'
   
 environment:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ install:
 # Adapt as necessary starting from here
 
 build_script:
-  - Rscript -e "install.packages('xfun', repos = 'https://cloud.r-project.org')"
   - travis-tool.sh install_github r-lib/devtools
   - travis-tool.sh install_deps
   - travis-tool.sh install_github tidyverse/dplyr

--- a/tests/testthat/print/knit_print-summary.txt
+++ b/tests/testthat/print/knit_print-summary.txt
@@ -1,3 +1,5 @@
+Table: Data summary
+
 |                         |     |
 |:------------------------|:----|
 |Name                     |iris |

--- a/tests/testthat/print/knit_print.txt
+++ b/tests/testthat/print/knit_print.txt
@@ -1,4 +1,6 @@
 
+Table: Data summary
+
 |                         |     |
 |:------------------------|:----|
 |Name                     |iris |


### PR DESCRIPTION
Two tests in this package need to be updated accordingly.

This is because you provided the caption to `knitr::kable()`: https://github.com/ropensci/skimr/blob/b8be86090de8c5daf52f062f260aa5694880c994/R/skim_print.R#L166

In previous versions of **knitr**, the caption was silently ignored, which was not a good idea. Since **knitr** 1.29, it has changed (https://github.com/yihui/knitr/pull/1830). It will be great if you could update your tests accordingly. Thank you very much!