### PR TITLE
Adds support for predicates (Issue #611)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -91,7 +91,11 @@ Authors@R:
       person(given = "Kyle", 
              family = "Butts",
              role ="ctb",
-             email = "buttskyle96@gmail.com"))
+             email = "buttskyle96@gmail.com"),
+      person(given = "Bastian", 
+             family = "Torges",
+             role ="ctb",
+             email = "bastian.torges@gmail.com"))
 Description: A simple to use summary function that can be used with pipes
     and displays nicely in the console. The default summary statistics may
     be modified by the user as can the default formatting.  Support for

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -119,7 +119,7 @@ Imports:
     stringr (>= 1.1),
     tibble (>= 2.0.0),
     tidyr (>= 1.0),
-    tidyselect (>= 0.2.5),
+    tidyselect (>= 1.0.0),
     withr
 Suggests:
     covr,

--- a/R/skim.R
+++ b/R/skim.R
@@ -60,6 +60,7 @@
 #' # Use tidyselect
 #' skim(iris, Species)
 #' skim(iris, starts_with("Sepal"))
+#' skim(iris, where(is.numeric))
 #'
 #' # Skim also works groupwise
 #' iris %>%

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -88,14 +88,11 @@ skim_with <- function(...,
       data <- as.data.frame(data)
     }
     stopifnot(inherits(data, "data.frame"))
-
-    .vars <- rlang::quos(...)
-    cols <- names(data)
-    if (length(.vars) == 0) {
-      selected <- cols
-    } else {
-      selected <- tidyselect::vars_select(cols, !!!.vars)
-    }
+    
+    selected <- names(tidyselect::eval_select(rlang::expr(c(...)), data))
+    if (length(selected) == 0) {
+      selected <- names(data)
+    } 
 
     grps <- dplyr::groups(data)
     if (length(grps) > 0) {

--- a/man/skim.Rd
+++ b/man/skim.Rd
@@ -86,6 +86,7 @@ skim(iris)
 # Use tidyselect
 skim(iris, Species)
 skim(iris, starts_with("Sepal"))
+skim(iris, where(is.numeric))
 
 # Skim also works groupwise
 iris \%>\%

--- a/tests/testthat/test-skim.R
+++ b/tests/testthat/test-skim.R
@@ -848,6 +848,17 @@ test_that("Tidyselect helpers work as expected", {
   )
 })
 
+test_that("Tidyselect predicates work as expected", {
+  input <- skim(iris, where(is.numeric))
+  
+  expect_n_rows(input, 4)
+  expect_n_columns(input, 12)
+  expect_identical(
+    unname(input$skim_variable),
+    c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width")
+  )
+})
+
 test_that("Skimming a grouped df works as expected", {
   grouped <- dplyr::group_by(mtcars, cyl, gear)
   input <- skim(grouped, mpg, disp)


### PR DESCRIPTION
I gave fixing #611 a try. As predicates were introduced in tidyselect 1.0 this changes the required tidyselect version.