### PR TITLE
Set ignore.case = FALSE in `tidyselect::starts_withs()`

### DIFF
--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -358,7 +358,7 @@ reshape_skimmed <- function(column, skimmed, groups) {
   out <- dplyr::select(
     as.data.frame(skimmed),
     !!!groups,
-    tidyselect::starts_with(delim_name)
+    tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )
   set_clean_names(out)
 }

--- a/tests/testthat/test-get_skimmers.R
+++ b/tests/testthat/test-get_skimmers.R
@@ -2,7 +2,7 @@ context("Get skimmers")
 
 test_that("get_sfl() behaves correctly", {
   my_sfl <- get_sfl("numeric")
-  expect_is(my_sfl, "skimr_function_list")
+  expect_s3_class(my_sfl, "skimr_function_list")
   expect_equal(my_sfl$skim_type, "numeric")
   expect_named(my_sfl$funs, c(
     "mean", "sd", "p0", "p25", "p50", "p75", "p100", "hist"

--- a/tests/testthat/test-reshape.R
+++ b/tests/testthat/test-reshape.R
@@ -3,7 +3,7 @@ context("Reshaping a skim_df")
 test_that("You can parition a skim_df", {
   skimmed <- skim(iris)
   input <- partition(skimmed)
-  expect_is(input, "skim_list")
+  expect_s3_class(input, "skim_list")
   expect_length(input, 2)
   expect_named(input, c("factor", "numeric"))
   attrs <- attributes(input)
@@ -20,7 +20,7 @@ test_that("You can parition a skim_df", {
   )
 
   # Subtables
-  expect_is(input$factor, c("one_skim_df", "tbl_df", "tbl", "data.frame"))
+  expect_s3_class(input$factor, c("one_skim_df", "tbl_df", "tbl", "data.frame"))
   expect_n_rows(input$factor, 1)
   expect_n_columns(input$factor, 6)
   expect_named(input$factor, c(
@@ -28,7 +28,7 @@ test_that("You can parition a skim_df", {
     "top_counts"
   ))
 
-  expect_is(input$numeric, c("one_skim_df", "tbl_df", "tbl", "data.frame"))
+  expect_s3_class(input$numeric, c("one_skim_df", "tbl_df", "tbl", "data.frame"))
   expect_n_rows(input$numeric, 4)
   expect_n_columns(input$numeric, 11)
   expect_named(input$numeric, c(
@@ -48,7 +48,7 @@ test_that("Partitioning works in a round trip", {
 test_that("You can yank a subtable from a skim_df", {
   skimmed <- skim(iris)
   input <- yank(skimmed, "numeric")
-  expect_is(input, c("one_skim_df", "tbl_df", "tbl", "data.frame"))
+  expect_s3_class(input, c("one_skim_df", "tbl_df", "tbl", "data.frame"))
   expect_n_rows(input, 4)
   expect_n_columns(input, 11)
   expect_named(input, c(

--- a/tests/testthat/test-sfl.R
+++ b/tests/testthat/test-sfl.R
@@ -11,13 +11,13 @@ test_that("Zero-length sfl's supported", {
 
 test_that("The interface for sfl's separates keep and drop functions", {
   input <- sfl(mad = mad, hist = NULL, skim_type = "test")
-  expect_is(input, "skimr_function_list")
+  expect_s3_class(input, "skimr_function_list")
   expect_length(input, 2)
   expect_named(input, c("funs", "skim_type"))
   expect_identical(input$skim_type, "test")
 
   funs <- input$funs
-  expect_is(funs, "list")
+  expect_type(funs, "list")
   expect_named(funs, c("mad", "hist"))
 })
 

--- a/tests/testthat/test-skim.R
+++ b/tests/testthat/test-skim.R
@@ -909,3 +909,12 @@ test_that("Skimming without charts produces no ts line charts", {
   input <- skim_without_charts(freeny, y)
   expect_null(iris$ts.line_graph)
 })
+
+test_that("Skimming succeeds when column names are similar", {
+  input <- data.frame(
+    x = 1:10,
+    X = 11:20
+  )
+  skimmed <- skim(input)
+  expect_s3_class(skimmed, "skim_df")
+})

--- a/tests/testthat/test-skim.R
+++ b/tests/testthat/test-skim.R
@@ -8,10 +8,10 @@ test_that("skim returns expected response for numeric vectors", {
   expect_n_columns(input, 12)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "numeric.mean", "numeric.sd", "numeric.p0", "numeric.p25",
@@ -203,10 +203,10 @@ test_that("skim returns expected response for character vectors", {
   expect_n_columns(input, 9)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "character.min", "character.max", "character.empty",
@@ -244,10 +244,10 @@ test_that("skim returns expected response for logical vectors", {
   expect_n_columns(input, 6)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "logical.mean", "logical.count"
@@ -294,10 +294,10 @@ test_that("skim returns expected response for complex vectors", {
   expect_n_columns(input, 5)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(
     input,
     c(
@@ -333,10 +333,10 @@ test_that("skim returns expected response for Date vectors", {
   expect_n_columns(input, 8)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "Date.min", "Date.max", "Date.median", "Date.n_unique"
@@ -371,10 +371,10 @@ test_that("skim returns expected response for ts vectors", {
   expect_n_columns(input, 14)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "ts.start", "ts.end", "ts.frequency", "ts.deltat", "ts.mean", "ts.sd",
@@ -422,10 +422,10 @@ test_that("skim returns expected response for POSIXct vectors", {
   expect_n_columns(input, 8)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "POSIXct.min", "POSIXct.max", "POSIXct.median",
@@ -479,10 +479,10 @@ test_that("skim returns expected response for list (not AsIs) vectors", {
   expect_n_columns(input, 7)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "list.n_unique", "list.min_length", "list.max_length"
@@ -518,10 +518,10 @@ test_that("skim returns expected response for list with all NA's", {
   expect_n_columns(input, 7)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "list.n_unique", "list.min_length", "list.max_length"
@@ -557,10 +557,10 @@ test_that("skim returns expected response for asis vectors", {
   expect_n_columns(input, 7)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "AsIs.n_unique", "AsIs.min_length", "AsIs.max_length"
@@ -598,10 +598,10 @@ test_that("skim returns expected response for difftime vectors", {
   expect_n_columns(input, 8)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "difftime.min", "difftime.max", "difftime.median",
@@ -638,10 +638,10 @@ test_that("skim returns expected response for lubridate Timespan vectors", {
   expect_n_columns(input, 8)
   
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "Timespan.min", "Timespan.max", "Timespan.median",
@@ -682,10 +682,10 @@ test_that("skim handles objects with multiple classes", {
   expect_n_columns(input, 8)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "Date.min", "Date.max", "Date.median", "Date.n_unique"
@@ -703,10 +703,10 @@ test_that("skim treats unknown classes as character", {
   expect_warning(input <- skim(x))
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "character.min", "character.max", "character.empty",
@@ -735,10 +735,10 @@ test_that("skim handles objects with two unknown classes", {
   expect_warning(input <- skim(x))
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "character.min", "character.max", "character.empty",
@@ -768,10 +768,10 @@ test_that("Skimming a complete data frame works as expected", {
   expect_n_columns(input, 15)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "n_missing", "complete_rate",
     "factor.ordered", "factor.n_unique", "factor.top_counts",
@@ -803,10 +803,10 @@ test_that("successfully skim mixed data types with common skimmers", {
   expect_n_rows(input, 2)
   expect_n_columns(input, 12)
 
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(
     input,
     c(
@@ -857,10 +857,10 @@ test_that("Skimming a grouped df works as expected", {
   expect_n_columns(input, 14)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "cyl", "gear", "n_missing",
     "complete_rate", "numeric.mean", "numeric.sd", "numeric.p0",
@@ -888,10 +888,10 @@ test_that("Skimming a grouped df works when selecting exactly one variable", {
   expect_n_columns(input, 14)
 
   # classes
-  expect_is(input, "skim_df")
-  expect_is(input, "tbl_df")
-  expect_is(input, "tbl")
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "skim_df")
+  expect_s3_class(input, "tbl_df")
+  expect_s3_class(input, "tbl")
+  expect_s3_class(input, "data.frame")
   expect_named(input, c(
     "skim_type", "skim_variable", "cyl", "gear", "n_missing",
     "complete_rate", "numeric.mean", "numeric.sd", "numeric.p0",

--- a/tests/testthat/test-skim_print.R
+++ b/tests/testthat/test-skim_print.R
@@ -32,7 +32,7 @@ test_that("knit_print produces expected results", {
   withr::local_options(list(cli.unicode = FALSE))
   skimmed <- skim(iris)
   input <- knit_print(skimmed)
-  expect_is(input, "knit_asis")
+  expect_s3_class(input, "knit_asis")
   expect_length(input, 1)
   if (packageVersion("knitr") <= "1.28") {
     expect_matches_file(input, "print/knit_print-knitr_old.txt")
@@ -68,7 +68,7 @@ test_that("knit_print appropriately falls back to tibble printing", {
       "print/knit_print-fallback-dplyrv1.txt"
     )
   }
-  expect_is(input, "data.frame")
+  expect_s3_class(input, "data.frame")
 })
 
 test_that("Summaries can be suppressed within knitr", {


### PR DESCRIPTION
Fixes #615.

Also resolves deprecation of expect_is() in testthat.