### PR TITLE
Round digits in print.skim_df

### DIFF
--- a/R/skim_print.R
+++ b/R/skim_print.R
@@ -37,6 +37,9 @@
 #' @param rule_width  Width of the cli rules in printed skim object. Defaults
 #'     to base::options()$width
 #' @param summary_rule_width Width of Data Summary cli rule, defaults to 40.
+#' @param round_early Whether floating point numbers should be displayed with 
+#'   their max precision or be displayed with rounding to 4 decimal places. 
+#'   Defaults to `TRUE`.
 #' @name print
 NULL
 
@@ -52,9 +55,14 @@ print.skim_df <- function(x,
                           ),
                           rule_width = base::options()$width,
                           summary_rule_width = 40,
+                          round_early = TRUE,
                           ...) {
   withr::local_options(list(crayon.enabled = FALSE))
   if (is_skim_df(x) && nrow(x) > 0) {
+    if(round_early) {
+      x <- dplyr::mutate_if(x, is.double, function(y) round(y,4))
+    }
+
     if (include_summary) {
       print(summary(x), .summary_rule_width = summary_rule_width, ...)
     }

--- a/man/print.Rd
+++ b/man/print.Rd
@@ -17,6 +17,7 @@
   strip_metadata = getOption("skimr_strip_metadata", FALSE),
   rule_width = base::options()$width,
   summary_rule_width = 40,
+  round_early = TRUE,
   ...
 )
 
@@ -66,6 +67,10 @@ will print information about at most \code{tibble.max_extra_cols} extra columns.
 to base::options()$width}
 
 \item{summary_rule_width}{Width of Data Summary cli rule, defaults to 40.}
+
+\item{round_early}{Whether floating point numbers should be displayed with
+their max precision or be displayed with rounding to 4 decimal places.
+Defaults to \code{TRUE}.}
 
 \item{...}{Other arguments passed on to individual methods.}
 


### PR DESCRIPTION
Closes #479

Added an additional argument `round_early = TRUE` to `print.skim_df`. If `round_early` is `TRUE` all doubles in the `skim_df` are rounded with `round(skim_df, 4)` before printing. 

