### PR TITLE
Replace as.data.frame to improve performance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -99,7 +99,11 @@ Authors@R:
       person(given = "Rick",
              family = "Saporta",
              role = "ctb",
-             email = "Rick@TheFarmersDog.com")
+             email = "Rick@TheFarmersDog.com"),
+      person(given = "Henry",
+             family = "Morgan Stewart",
+             role = "ctb",
+             email = "henry.morganstewart@gmail.com")
              )
 Description: A simple to use summary function that can be used with pipes
     and displays nicely in the console. The default summary statistics may

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,9 @@
 
 *   skim() used within a function now prints the data frame name.
 *   we have improved the interaction between focus() and the print methods.
-
     *  columns selected in focus() are shown in the correct order
     *  some edge cases relating to empty skim types have been improved
+*   we have improved performance when handling large data with many columns.
 
 # skimr 2.1.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 ### NEW FEATURES
 
 *   skim() used within a function now prints the data frame name.
+*   we have improved the interaction between focus() and the print methods.
+
+    *  columns selected in focus() are shown in the correct order
+    *  some edge cases relating to empty skim types have been improved
 
 # skimr 2.1.3
 

--- a/R/skim_obj.R
+++ b/R/skim_obj.R
@@ -128,6 +128,21 @@ has_skim_type_attribute <- function(object) {
   )
 }
 
+#' @describeIn skim-obj Does the object have skimmers?
+#' @export
+has_skimmers <- function(object) {
+  base <- base_skimmers(object)
+  skimmers <- reconcile_skimmers(
+    object,
+    group_names(object),
+    base
+  )
+  make_issue(
+    any(lengths(skimmers) > 0, base %in% names(object)),
+    "does not have defined skimmers."
+  )
+}
+
 #' @describeIn skim-obj Is the object a data frame?
 #' @export
 is_data_frame <- function(object) {
@@ -146,7 +161,8 @@ is_skim_df <- function(object) {
     is_data_frame(object),
     has_type_column(object),
     has_variable_column(object),
-    has_skimr_attributes(object)
+    has_skimr_attributes(object),
+    has_skimmers(object)
   )
 }
 

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -390,6 +390,7 @@ reshape_skimmed <- function(column, skimmed, groups) {
   out <- dplyr::select(
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     tibble::as_tibble(skimmed),
 =======
     as_tibble(skimmed),
@@ -397,6 +398,9 @@ reshape_skimmed <- function(column, skimmed, groups) {
 =======
     as_tibble(skimmed),
 >>>>>>> 406674d (relace-as.data.frame)
+=======
+    tibble::as_tibble(skimmed),
+>>>>>>> e27fd8d (fn)
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -388,15 +388,7 @@ build_results <- function(skimmed, variable_names, groups) {
 reshape_skimmed <- function(column, skimmed, groups) {
   delim_name <- paste0(column, "_", NAME_DELIMETER)
   out <- dplyr::select(
-<<<<<<< HEAD
-<<<<<<< HEAD
     tibble::as_tibble(skimmed),
-=======
-    as_tibble(skimmed),
->>>>>>> ded9895 (relace-as.data.frame)
-=======
-    as_tibble(skimmed),
->>>>>>> 406674d (relace-as.data.frame)
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -388,7 +388,7 @@ build_results <- function(skimmed, variable_names, groups) {
 reshape_skimmed <- function(column, skimmed, groups) {
   delim_name <- paste0(column, "_", NAME_DELIMETER)
   out <- dplyr::select(
-    as_tibble(skimmed),
+    tibble::as_tibble(skimmed),
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -391,6 +391,7 @@ reshape_skimmed <- function(column, skimmed, groups) {
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     tibble::as_tibble(skimmed),
 =======
     as_tibble(skimmed),
@@ -401,6 +402,9 @@ reshape_skimmed <- function(column, skimmed, groups) {
 =======
     tibble::as_tibble(skimmed),
 >>>>>>> e27fd8d (fn)
+=======
+    as_tibble(skimmed),
+>>>>>>> ded9895 (relace-as.data.frame)
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -389,10 +389,14 @@ reshape_skimmed <- function(column, skimmed, groups) {
   delim_name <- paste0(column, "_", NAME_DELIMETER)
   out <- dplyr::select(
 <<<<<<< HEAD
+<<<<<<< HEAD
     tibble::as_tibble(skimmed),
 =======
     as_tibble(skimmed),
 >>>>>>> ded9895 (relace-as.data.frame)
+=======
+    as_tibble(skimmed),
+>>>>>>> 406674d (relace-as.data.frame)
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -388,11 +388,7 @@ build_results <- function(skimmed, variable_names, groups) {
 reshape_skimmed <- function(column, skimmed, groups) {
   delim_name <- paste0(column, "_", NAME_DELIMETER)
   out <- dplyr::select(
-<<<<<<< HEAD
     tibble::as_tibble(skimmed),
-=======
-    as_tibble(skimmed),
->>>>>>> 406674d (relace-as.data.frame)
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -392,6 +392,7 @@ reshape_skimmed <- function(column, skimmed, groups) {
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     tibble::as_tibble(skimmed),
 =======
     as_tibble(skimmed),
@@ -405,6 +406,9 @@ reshape_skimmed <- function(column, skimmed, groups) {
 =======
     as_tibble(skimmed),
 >>>>>>> ded9895 (relace-as.data.frame)
+=======
+    as_tibble(skimmed),
+>>>>>>> 406674d (relace-as.data.frame)
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -388,7 +388,7 @@ build_results <- function(skimmed, variable_names, groups) {
 reshape_skimmed <- function(column, skimmed, groups) {
   delim_name <- paste0(column, "_", NAME_DELIMETER)
   out <- dplyr::select(
-    as.data.frame(skimmed),
+    as_tibble(skimmed),
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -393,6 +393,7 @@ reshape_skimmed <- function(column, skimmed, groups) {
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
     tibble::as_tibble(skimmed),
 =======
     as_tibble(skimmed),
@@ -409,6 +410,9 @@ reshape_skimmed <- function(column, skimmed, groups) {
 =======
     as_tibble(skimmed),
 >>>>>>> 406674d (relace-as.data.frame)
+=======
+    tibble::as_tibble(skimmed),
+>>>>>>> e27fd8d (fn)
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -388,31 +388,7 @@ build_results <- function(skimmed, variable_names, groups) {
 reshape_skimmed <- function(column, skimmed, groups) {
   delim_name <- paste0(column, "_", NAME_DELIMETER)
   out <- dplyr::select(
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
     tibble::as_tibble(skimmed),
-=======
-    as_tibble(skimmed),
->>>>>>> ded9895 (relace-as.data.frame)
-=======
-    as_tibble(skimmed),
->>>>>>> 406674d (relace-as.data.frame)
-=======
-    tibble::as_tibble(skimmed),
->>>>>>> e27fd8d (fn)
-=======
-    as_tibble(skimmed),
->>>>>>> ded9895 (relace-as.data.frame)
-=======
-    as_tibble(skimmed),
->>>>>>> 406674d (relace-as.data.frame)
-=======
-    tibble::as_tibble(skimmed),
->>>>>>> e27fd8d (fn)
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -388,7 +388,11 @@ build_results <- function(skimmed, variable_names, groups) {
 reshape_skimmed <- function(column, skimmed, groups) {
   delim_name <- paste0(column, "_", NAME_DELIMETER)
   out <- dplyr::select(
+<<<<<<< HEAD
     tibble::as_tibble(skimmed),
+=======
+    as_tibble(skimmed),
+>>>>>>> ded9895 (relace-as.data.frame)
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -388,7 +388,11 @@ build_results <- function(skimmed, variable_names, groups) {
 reshape_skimmed <- function(column, skimmed, groups) {
   delim_name <- paste0(column, "_", NAME_DELIMETER)
   out <- dplyr::select(
+<<<<<<< HEAD
     tibble::as_tibble(skimmed),
+=======
+    as_tibble(skimmed),
+>>>>>>> 406674d (relace-as.data.frame)
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )

--- a/tests/testthat/dplyr/select-skim.txt
+++ b/tests/testthat/dplyr/select-skim.txt
@@ -1,22 +1,8 @@
--- Data Summary ------------------------
-                           Values
-Name                       iris  
-Number of rows             150   
-Number of columns          5     
-_______________________          
-Column type frequency:           
-  factor                   1     
-  numeric                  4     
-________________________         
-Group variables            None  
-
--- Variable type: factor ---------------------------------------------------------------------------
-  skim_variable
-1 Species      
-
--- Variable type: numeric --------------------------------------------------------------------------
-  skim_variable
-1 Sepal.Length 
-2 Sepal.Width  
-3 Petal.Length 
-4 Petal.Width  
+# A tibble: 5 x 2
+  skim_type skim_variable
+  <chr>     <chr>        
+1 factor    Species      
+2 numeric   Sepal.Length 
+3 numeric   Sepal.Width  
+4 numeric   Petal.Length 
+5 numeric   Petal.Width  

--- a/tests/testthat/helper-expectations.R
+++ b/tests/testthat/helper-expectations.R
@@ -39,6 +39,10 @@ expect_print_matches_file <- function(object,
                                         TRUE
                                       ),
                                       width = 100,
+                                      update = getOption(
+                                        "skimr_update_print",
+                                        FALSE
+                                      ),
                                       ...) {
   if (skip_on_windows) testthat::skip_on_os("windows")
   if (skip_on_windows) testthat::skip_if_not(l10n_info()$`UTF-8`)
@@ -47,7 +51,7 @@ expect_print_matches_file <- function(object,
     testthat::expect_known_output(
       print(object, ...),
       filename,
-      update = FALSE,
+      update = update,
       width = width
     )
   })
@@ -55,7 +59,10 @@ expect_print_matches_file <- function(object,
 
 expect_matches_file <- function(object,
                                 file,
-                                update = FALSE,
+                                update = getOption(
+                                  "skimr_update_print",
+                                  FALSE
+                                ),
                                 skip_on_windows = getOption(
                                   "skimr_skip_on_windows",
                                   TRUE

--- a/tests/testthat/test-reshape.R
+++ b/tests/testthat/test-reshape.R
@@ -85,7 +85,7 @@ test_that("focus() matches select(data, skim_type, skim_variable, ...)", {
   expected <- dplyr::select(
     skimmed, skim_type, skim_variable, n_missing
   )
-  expect_identical(focus(skimmed, n_missing), expected)
+  expect_equal(focus(skimmed, n_missing), expected, check.attributes = FALSE)
 })
 
 test_that("focus() does not allow dropping skim metadata columns", {


### PR DESCRIPTION
This very small PR replaces `as.data.frame` with `as_tibble` inside the `reshape_skimmed` function. This alone has a significant impact on performance, particularly for large datasets: `as.data.frame` is known to be slow (see [here](https://adv-r.hadley.nz/perf-improve.html#as.data.frame)) and in combination with increased calls to `reshape_skimmed` as variables are added leads to an exponential degradation in performance with dataset size.

To demonstrate, build a moderately sized dataset:

```R

library(tidyverse)
library(stringi)
library(skimr)

number_rows <- 100000
coltypes <- c(rep("numeric",333), rep("date",333), rep("char", 333))

large_test_df <- bind_cols(
  map(seq_len(length(coltypes)), function(col){
    if(coltypes[col] == "numeric") content <- round(runif(number_rows, 0, col), sample(c(0,1,2,3), 1))
    if(coltypes[col] == "date")    content <- sample(seq(as.Date('1950-01-01'), Sys.Date(), by="day"), number_rows, replace = T)
    if(coltypes[col] == "char")    content <- sample(stri_rand_strings(500, sample(c(1,3,5), 1)), number_rows, replace = T)
    tibble(!!sym(str_c("col",col)) := content)
  }
  ))

system.time(full_version <- skimr::skim(large_test_df))

```
```
   user  system elapsed 
 36.603   1.491  38.426 
```

Using the previous `develop` branch is almost an order of magnitude slower:

```
   user  system elapsed 
243.928  28.356 272.908 
```

The difference becomes greater as variables are added.

**A further rework/simplification of the `skim_by_type` methods can speed things up further still**
