### PR TITLE
Replace as.data.frame to improve performance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -99,7 +99,11 @@ Authors@R:
       person(given = "Rick",
              family = "Saporta",
              role = "ctb",
-             email = "Rick@TheFarmersDog.com")
+             email = "Rick@TheFarmersDog.com"),
+      person(given = "Henry",
+             family = "Morgan Stewart",
+             role = "ctb",
+             email = "henry.morganstewart@gmail.com"),
              )
 Description: A simple to use summary function that can be used with pipes
     and displays nicely in the console. The default summary statistics may

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -103,8 +103,8 @@ Authors@R:
       person(given = "Henry",
              family = "Morgan Stewart",
              role = "ctb",
-             email = "henry.morganstewart@gmail.com"),
-             )
+             email = "henry.morganstewart@gmail.com")
+       )
 Description: A simple to use summary function that can be used with pipes
     and displays nicely in the console. The default summary statistics may
     be modified by the user as can the default formatting.  Support for

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 
     *  columns selected in focus() are shown in the correct order
     *  some edge cases relating to empty skim types have been improved
+*   we have improved performance when handling large data with many columns.
 
 # skimr 2.1.3
 

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -388,7 +388,7 @@ build_results <- function(skimmed, variable_names, groups) {
 reshape_skimmed <- function(column, skimmed, groups) {
   delim_name <- paste0(column, "_", NAME_DELIMETER)
   out <- dplyr::select(
-    as.data.frame(skimmed),
+    tibble::as_tibble(skimmed),
     !!!groups,
     tidyselect::starts_with(delim_name, ignore.case = FALSE)
   )


### PR DESCRIPTION
This PR supersedes #674 to cleanly rebase and add better benchmarking. 

This very small PR replaces `as.data.frame` with `as_tibble` inside the `reshape_skimmed` function. This has a significant impact on performance, particularly for large datasets: `as.data.frame` is known to be slow (see [here](https://adv-r.hadley.nz/perf-improve.html#as.data.frame)) and in combination with increased calls to `reshape_skimmed` as variables are added leads to an exponential degradation in performance with dataset size.

![image](https://user-images.githubusercontent.com/19331059/147858274-d2e5e2fe-ef22-4b73-be82-284ff4dec57f.png)

<details>
  <summary>code</summary>
  
  ```R
library(tidyverse)
library(stringi)
library(skimr)
library(microbenchmark)

#devtools::install_github("ropensci/skimr@develop")

#### Make some wide test data
rows <- c(100,1000,10000)
cols <- c(30,90,300,600,900,1200)

results <- list()

for(r in 1:length(rows)){
  
  results[[r]] <- list()

  for(c in 1:length(cols)){
    number_rows <- rows[r]
    
    coltypes <- c(rep("numeric",ceiling(cols[c]/3)), rep("date",ceiling(cols[c]/3)), rep("char", ceiling(cols[c]/3)))
    
    large_test_df <- bind_cols(
      map(seq_len(length(coltypes)), function(col){
        if(coltypes[col] == "numeric") content <- round(runif(number_rows, 0, col), sample(c(0,1,2,3), 1))
        if(coltypes[col] == "date")    content <- sample(seq(as.Date('1950-01-01'), Sys.Date(), by="day"), number_rows, replace = T)
        if(coltypes[col] == "char")    content <- sample(stri_rand_strings(500, sample(c(1,3,5), 1)), number_rows, replace = T)
        tibble(!!sym(str_c("col",col)) := content)
      }))
    
    reshape_skimmed_df <- function (column, skimmed, groups) {
      delim_name <- paste0(column, "_", NAME_DELIMETER)
      out <- dplyr::select(as.data.frame(skimmed), !!!groups, tidyselect::starts_with(delim_name, ignore.case = FALSE))
      set_clean_names(out)
      }
    
    reshape_skimmed_tibble <- function (column, skimmed, groups){
        delim_name <- paste0(column, "_", NAME_DELIMETER)
        out <- dplyr::select(tidyr::as_tibble(skimmed), !!!groups, tidyselect::starts_with(delim_name, ignore.case = FALSE))
        set_clean_names(out)
        }

    results[[r]][[c]] <- microbenchmark(
      {
      assignInNamespace("reshape_skimmed", `environment<-`(reshape_skimmed_df, environment(skimr:::build_results)), ns="skimr")
      full_version_2 <- skim(large_test_df)
      },
      {
        assignInNamespace("reshape_skimmed", `environment<-`(reshape_skimmed_tibble, environment(skimr:::build_results)), ns="skimr", envir =  environment(skimr:::build_results))
        full_version <- skim(large_test_df)
      },
      times = 3)
  }
}
  ```
</details>

Using `as_tibble` the bottleneck of reshaping data column-wise is removed and time now scales linearly. Furthermore number of rows has minimal effect on the overall time taken.

