### PR TITLE
Fixes for dev purrr

### DIFF
--- a/R/reshape.R
+++ b/R/reshape.R
@@ -247,7 +247,7 @@ to_long.skim_df <- function(.data, ..., skim_fun = skim) {
     key = "stat",
     value = "formatted",
     na.rm = TRUE,
-    -.data$skim_type,
-    -.data$skim_variable
+    -"skim_type",
+    -"skim_variable"
   )
 }

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -258,21 +258,23 @@ skim_class <- function(column) {
 }
 
 get_local_skimmers <- function(classes, local_skimmers) {
-  all_matches <- local_skimmers[classes]
-  safe_modify <- purrr::possibly(purrr::list_modify, NULL)
-  add_types <- purrr::map2(
-    all_matches,
-    classes,
-    ~ safe_modify(.x, skim_type = .y)
-  )
-  purrr::detect(add_types, ~ !is.null(.x))
+  local_classes <- intersect(classes, names(local_skimmers))
+  if (length(local_classes) == 0) {
+    return(NULL)
+  }
+  
+  first_class <- local_classes[[1]]
+  
+  out <- local_skimmers[[first_class]]
+  out$skim_type <- first_class
+  out
 }
 
 merge_skimmers <- function(locals, defaults, append) {
   if (!append || locals$skim_type != defaults$skim_type) {
     locals
   } else {
-    defaults$funs <- purrr::list_modify(defaults$funs, !!!locals$funs)
+    defaults$funs <- purrr::compact(purrr::list_modify(defaults$funs, !!!locals$funs))
     defaults
   }
 }

--- a/R/skim_with.R
+++ b/R/skim_with.R
@@ -125,7 +125,7 @@ skim_with <- function(...,
       )
     )
     structure(
-      tidyr::unnest(nested, .data$skimmed),
+      tidyr::unnest(nested, "skimmed"),
       class = c("skim_df", "tbl_df", "tbl", "data.frame"),
       data_rows = nrow(data),
       data_cols = ncol(data),
@@ -371,7 +371,7 @@ build_results <- function(skimmed, variable_names, groups) {
       skim_variable = variable_names,
       by_variable = purrr::map(variable_names, reshape_skimmed, skimmed, groups)
     )
-    tidyr::unnest(out, .data$by_variable)
+    tidyr::unnest(out, "by_variable")
   } else {
     out <- dplyr::select(
       as.data.frame(skimmed),

--- a/tests/testthat/test-skim_with.R
+++ b/tests/testthat/test-skim_with.R
@@ -155,29 +155,30 @@ test_that("Sfl's can be passed as an unquoted list", {
 })
 
 test_that("Doubles and integers are both 'numeric'", {
-  df <- dplyr::mutate(faithful, eruptions = as.integer(eruptions))
+  df <- data.frame(int = 1:3, dbl = 1:3 + 0.5)
   my_skim <- skim_with(numeric = sfl(hist = NULL))
   input <- my_skim(df)
-  expect_false("hist" %in% names(input))
-  used <- attr(input, "skimmers_used")
-  expect_identical(
-    used, list(numeric = c("mean", "sd", "p0", "p25", "p50", "p75", "p100"))
+  
+  expect_false("numeric.hist" %in% names(input))
+  expect_equal(
+    attr(input, "skimmers_used")$numeric,
+    c("mean", "sd", "p0", "p25", "p50", "p75", "p100")
   )
 })
 
 test_that("Defining an integer sfl changes behavior", {
-  df <- dplyr::mutate(faithful, eruptions = as.integer(eruptions))
+  df <- data.frame(int = 1:3, dbl = 1:3 + 0.5)
   my_skim <- expect_message(
     skim_with(
       numeric = sfl(hist = NULL), integer = sfl(int_mean = mean)
     )
   )
   input <- my_skim(df)
-  expect_false("hist" %in% names(input))
+
+  expect_false("numeric.hist" %in% names(input))
   expect_true("integer.int_mean" %in% names(input))
-  used <- attr(input, "skimmers_used")
   expect_identical(
-    used,
+    attr(input, "skimmers_used"),
     list(
       integer = c("int_mean"),
       numeric = c("mean", "sd", "p0", "p25", "p50", "p75", "p100")


### PR DESCRIPTION
The root cause of the problem is that `list_modify(x, y = NULL)` now returns list(y = NULL)` rather than removing `y` as previously. So I made two changes:

* `merge_skimmers()` removes the NULL skimmers after merging

* I don't know why `get_local_skimmers()`  broke but once I figured out what it was doing, I rewrote it from first principles and it now works.

(Also includes some remaining tidyselect tweaks to avoid warnings in the tests)