### PR TITLE
Haven

### DIFF
--- a/R/get_skimmers.R
+++ b/R/get_skimmers.R
@@ -216,6 +216,7 @@ get_skimmers.AsIs <- function(column) {
 #'  Finds the appropriate skimmers for the underlying data in the vector.
 #' @export
 get_skimmers.haven_labelled <- function(column) {
+  stopifnot(requireNamespace("haven", quietly = TRUE))
   get_skimmers(vctrs::vec_data(column))
 }
 

--- a/tests/testthat/dplyr/filter-no-skim.txt
+++ b/tests/testthat/dplyr/filter-no-skim.txt
@@ -1,5 +1,5 @@
 # A tibble: 0 x 15
-# ... with 15 variables: skim_type <chr>, skim_variable <chr>, n_missing <int>,
-#   complete_rate <dbl>, factor.ordered <lgl>, factor.n_unique <int>, factor.top_counts <chr>,
-#   numeric.mean <dbl>, numeric.sd <dbl>, numeric.p0 <dbl>, numeric.p25 <dbl>, numeric.p50 <dbl>,
-#   numeric.p75 <dbl>, numeric.p100 <dbl>, numeric.hist <chr>
+# i 15 variables: skim_type <chr>, skim_variable <chr>, n_missing <int>, complete_rate <dbl>,
+#   factor.ordered <lgl>, factor.n_unique <int>, factor.top_counts <chr>, numeric.mean <dbl>,
+#   numeric.sd <dbl>, numeric.p0 <dbl>, numeric.p25 <dbl>, numeric.p50 <dbl>, numeric.p75 <dbl>,
+#   numeric.p100 <dbl>, numeric.hist <chr>


### PR DESCRIPTION
Fixes #737

While `haven` is suggested, we will see errors if it is not also loaded when skimming over labeled vectors.