### PR TITLE
Fix typo in vignette() call

### DIFF
--- a/R/skim.R
+++ b/R/skim.R
@@ -43,7 +43,7 @@
 #' If the rendered examples show unencoded values such as `<U+2587>` you will
 #' need to change your locale to allow proper rendering. Please review the
 #' *Using Skimr* vignette for more information
-#' (`vignette("Using_skimr", package = "skimr")`).
+#' (`vignette("skimr", package = "skimr")`).
 #'
 #' Otherwise, we export `skim_without_charts()` to produce summaries without the
 #' spark graphs. These are the source of the unicode dependency.


### PR DESCRIPTION
`?skimr::skim` says

>  Please review the _Using Skimr_ vignette for more information (‘vignette("Using_skimr", package = "skimr")’

```
Vignettes in package ‘skimr’:

extending_skimr         Extending skimr (source, html)
Skimr_defaults          Skimr defaults (source, html)
Using_fonts             Using Fonts (source, html)
skimr                   Using Skimr (source, html)
```

### Change proposed in this PR

Update `vignette("Using_skimr", package = "skimr")’ --> `vignette("Using_skimr", package = "skimr")’

### Other options 

change name of `vignettes/skimr.Rmd` to  `Using_vignettes/skimr.Rmd`

